### PR TITLE
0.10 - Compatibility with more JUnit parsers, output parsable XML to stdout in verbose mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,5 @@ yamllint -f parsable test.yaml | yamllint-junit -o yamllint-junit.xml
 ```
 
 ### Output
-* if there are any lint errors, full JUnit XML will be created
-* if there are no errors, empty JUnit XML will be created, this is for i.e. [Bamboo](https://www.atlassian.com/software/bamboo) JUnit parser plugin compatibility.
-It will break build if XML is missing or incorrect, and there is really no way of generating XML with *"PASSED"* tests in case of linter.
+* If there are any lint errors, JUnit XML will be created specifying the detailed description of each error as reported by yamllint 
+* If there are no lint errors, JUnit XML will be created denoting one successful testcase named 'no\_yamllint\_errors'. This is to maintain compatibility with JUnit parsers such as [Bamboo](https://www.atlassian.com/software/bamboo) which require that a properly formed JUnit file containing a minimum of one testcase be recorded in order to not fail builds.

--- a/yamllint_junit_bootstrap/bootstrap.py
+++ b/yamllint_junit_bootstrap/bootstrap.py
@@ -43,6 +43,7 @@ def main():
     parser.add_argument("-o", "--output", type=str, help="output XML to file", default=junit_xml_output)
     parser.add_argument("-v", "--verbose", action="store_true", help="print XML to console as command output", default=False)
     parser.add_argument("--version", action='version', version='%(prog)s ' + __version__)
+    parser.add_argument("--test-name", type=str, help="testsuite name to report in the JUnit file", default='yamllint')
 
     args = parser.parse_args()
 
@@ -69,7 +70,7 @@ def main():
     errors_count = 0
     skipped_count = 0
 
-    testsuite = ET.SubElement(testsuites, "testsuite", errors="0", skipped="0", failures="0", tests=str(len(lines)), time="0")
+    testsuite = ET.SubElement(testsuites, "testsuite", name=args.test_name, errors="0", skipped="0", failures="0", tests=str(len(lines)), time="0")
 
     if not lines:
         ET.SubElement(testsuite, "testcase", name="no_yamllint_errors")

--- a/yamllint_junit_bootstrap/bootstrap.py
+++ b/yamllint_junit_bootstrap/bootstrap.py
@@ -7,7 +7,7 @@ import sys
 import signal
 from os import isatty, path
 
-__version__ = "0.9"
+__version__ = "0.10"
 """Version of lib"""
 
 
@@ -71,8 +71,9 @@ def main():
 
     testsuite = ET.SubElement(testsuites, "testsuite", errors="0", skipped="0", failures="0", tests=str(len(lines)), time="0")
 
-    if 0 == len(lines):
-        ET.SubElement(testsuite, "testcase", name="dummy_testcase.py")
+    if not lines:
+        ET.SubElement(testsuite, "testcase", name="no_yamllint_errors")
+        testsuite.attrib["tests"] = "1"
     else:
         parsed_lines = []
         for line in lines:
@@ -108,7 +109,6 @@ def main():
     testsuite.attrib['skipped'] = str(skipped_count)
     tree = ET.ElementTree(testsuites)
     tree.write(args.output, encoding='utf8', method='xml')
-    parsed_lines_xml = ET.tostring(testsuites, encoding='utf8', method='xml')
 
     if args.verbose:
-        print(parsed_lines_xml)
+        tree.write(sys.stdout.buffer, encoding='utf8', method='xml')


### PR DESCRIPTION
This changeset implements the following features and bug fixes (as well as rewords the documentation appropriately):

- (bugfix) Report one test (instead of zero) in cases of an empty output from yamllint, as reporting a total number of testcases in the testsuite that differs from the the total number of testcase XML objects is invalid JUnit.

- (bugfix) Running in verbose mode under Python 3.x would result in output written to stdout that was not parsable as XML due to the addition of the `b'` prefix and single quote suffix. This patchset changes the behavior to write the raw XML data to stdout without performing any string formatting.

- (compatibility improvement) Some JUnit parsers require a 'name' attribute be added to the testsuite. This is now defined with the default value of 'yamllint' but may be overridden via the use of the --test-name CLI argument.