### PR TITLE
Correct name of yamllint in README instead of reading "yamllint-to-junit-to-junit"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[yamllint-junit](https://github.com/adrienverge/yamllint) to JUnit converter [![Build Status](https://travis-ci.com/wasilak/yamllint-junit.svg?branch=master)](https://travis-ci.com/wasilak/yamllint-junit)
+[yamllint](https://github.com/adrienverge/yamllint) to JUnit converter [![Build Status](https://travis-ci.com/wasilak/yamllint-junit.svg?branch=master)](https://travis-ci.com/wasilak/yamllint-junit)
 ---
 
 ### Installation


### PR DESCRIPTION
I assume this is what this meant to say? I was a little confused reading to start with :D 